### PR TITLE
SubmitBtnのValue変更

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -20,4 +20,4 @@
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField
-      = f.submit '更新する', class: 'SettingGroupForm__button'
+      = f.submit class: 'SettingGroupForm__button'


### PR DESCRIPTION
#What
add/groups/_form.html.hamlのサブミットボタンのテキスト変更。
変更前　"更新する"  → 変更後 ""

#Why
サブミットボタンのテキストが仕様書と相違していたため。